### PR TITLE
Fix coveralls reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*


### PR DESCRIPTION
A recent update to the coveralls tool seems to break when there's no .coveragerc.

This PR adds a dummy rc file so the reports come through again.