### PR TITLE
Fix examples issue

### DIFF
--- a/amen/version.py
+++ b/amen/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '0.0'
-version = '0.0.1'
+version = '0.0.1rc2'

--- a/amen/version.py
+++ b/amen/version.py
@@ -3,4 +3,4 @@
 """Version info"""
 
 short_version = '0.0'
-version = '0.0.1rc2'
+version = '0.0.2'

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,6 @@ import imp
 import os
 
 version = imp.load_source('amen.version', 'amen/version.py')
-
-# Tacky fix to include examples as data files
-current_path = os.path.abspath(os.path.dirname(__file__))
-example_path = os.path.join(current_path, 'examples')
-example_files = os.listdir(example_path)
-example_paths = [os.path.join('examples', f) for f in example_files]
-
 setup(
     name='amen',
     version=version.version,
@@ -19,7 +12,6 @@ setup(
     download_url='http://github.com/algorithmic-music-exploration/amen/releases',
     packages=find_packages(),
     package_data={'amen': ['example_audio/*.wav']},
-    data_files=[('examples', example_paths)],
     classifiers=[
         "License :: OSI Approved :: ISC License (ISCL)",
         "Programming Language :: Python",


### PR DESCRIPTION
Hilariously, it turns out that my hack to put the examples into `data_files` never worked, and was breaking pip installation for 0.0.1.  

So, I'm getting rid of them.  I'll try to find a way to put them back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algorithmic-music-exploration/amen/98)
<!-- Reviewable:end -->
