### PR TITLE
fix flake8 errors

### DIFF
--- a/amen/__init__.py
+++ b/amen/__init__.py
@@ -6,7 +6,5 @@ AMEN
 A toolbox for algorithmic remixing, after Echo Nest Remix.
 '''
 from .feature import Feature
-from .timing import TimeSlice
-from .version import version as __version__
 
 __all__ = ['audio', 'Feature', 'utils']

--- a/amen/audio.py
+++ b/amen/audio.py
@@ -230,7 +230,7 @@ class Audio(object):
     def _get_timbre(self):
         """
         Gets timbre (MFCC) data, taking the first 20.
-        Note that the keys to the Feature are "mffc_<index>", 
+        Note that the keys to the Feature are "mffc_<index>",
         to avoid having a dict-like object with numeric keys.
 
         Parameters

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, find_packages
 
 import imp
-import os
 
 version = imp.load_source('amen.version', 'amen/version.py')
 setup(


### PR DESCRIPTION
Fixes flake8 errors, except for line length and `:` in slices - `black` takes care of both of those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/algorithmic-music-exploration/amen/119)
<!-- Reviewable:end -->
